### PR TITLE
Stop using deprecated `auto_ptr` when using C++11 or later

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -215,10 +215,10 @@ struct Builder {
   State* state_;
   const BuildConfig& config_;
   Plan plan_;
-#if __cplusplus < 201703L
-  std::auto_ptr<CommandRunner> command_runner_;
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+  std::unique_ptr<CommandRunner> command_runner_;  // auto_ptr was deprecated in C++11.
 #else
-  std::unique_ptr<CommandRunner> command_runner_;  // auto_ptr was removed in C++17.
+  std::auto_ptr<CommandRunner> command_runner_;
 #endif
   Status* status_;
 


### PR DESCRIPTION
`std::auto_ptr` was deprecated since C++11 and removed in C++17. Therefore, if C++11 is available, then it would be better to use `std::unique_ptr` rather than `std::auto_ptr`.